### PR TITLE
[fix] set C standard to C99

### DIFF
--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -5,5 +5,8 @@ find_package(precice REQUIRED CONFIG)
 find_package(MPI REQUIRED)
 
 add_executable(solverdummy-c-parallel solverdummy-c-parallel.c)
+
+set_property(TARGET solverdummy-c-parallel PROPERTY C_STANDARD 99)
+
 target_link_libraries(solverdummy-c-parallel PRIVATE precice::precice)
 target_link_libraries(solverdummy-c-parallel PRIVATE MPI::MPI_C)


### PR DESCRIPTION
On old compilers there could be errors like 
```
error: ‘for’ loop initial declarations are only allowed in C99 mode for (int i = 0; i < numberOfVertices; i++) { 
/enc/udev_PkWWa/work/shared/precice-parallel-solverdummies/c/solverdummy-c-parallel.c:69:3: note: use option -std=c99 or -std=gnu99 to compile your code 
```

This sets the requested C standard to C99.