### PR TITLE
Add Julia parallel dummies

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Current solver dummies included
 - C solver dummy: `c/solverdummy-c-parallel.cpp`
 - C++ solver dummy: `cpp/solverdummy-cpp-parallel.cpp`
 - Fortran solver dummy: `fortran/solverdummy-fortran-parallel.f90`
+- Julia solver dummy: `julia/solverdummy-julia-parallel.jl`
 - Python solver dummy: `python/solverdummy-python-parallel.py`
 
 
@@ -28,6 +29,10 @@ Current solver dummies included
 - CMake
 - A Fortran compiler
 - MPI (only tested with OpenMPI)
+
+**Julia dummy**
+- Julia `v1.6` or above
+- [Julia bindings for preCICE](https://github.com/precice/PreCICE.jl)
 
 **Python dummy additionally needs**
 - Python 3
@@ -159,6 +164,53 @@ Example:
 mpirun -n 4 ./solverdummy-cpp-parallel ../precice-config-parallel.xml SolverOne MeshOne
 mpirun -n 2 ./solverdummy-c-parallel ../precice-config-parallel.xml  SolverTwo MeshTwo
 ```
+
+### Setup 5: Julia and Julia
+
+The Julia solver dummy uses Julia's native parallelization and not the MPI wrapper.
+
+You need to add `<master:sockets/>` to the `precice-config-parallel.xml` file in both participants.
+
+Example:
+
+```xml
+<participant name="SolverOne">
+    <master:sockets/>
+    <use-mesh name="MeshOne" provide="yes"/>
+    <write-data name="dataOne" mesh="MeshOne" />
+    <read-data  name="dataTwo" mesh="MeshOne" />
+</participant>
+```
+
+Run the dummies with
+
+```shell
+julia solverdummy-julia-parallel.jl N ../precice-config-parallel.xml SolverOne
+julia solverdummy-julia-parallel.jl M ../precice-config-parallel.xml SolverTwo
+```
+
+Example:
+```shell
+julia solverdummy-julia-parallel.jl 4 ../precice-config-parallel.xml SolverOne
+julia solverdummy-julia-parallel.jl 2 ../precice-config-parallel.xml SolverTwo
+```
+
+## Setup 6: Julia and Python
+
+As with [Setup 5](#setup-5) you need to add `<master:sockets/>` to the `precice-config-parallel.xml` file in both participants.
+
+```shell
+mpirun -n N python3 solverdummy-python-parallel.py ../precice-config-parallel.xml SolverOne MeshOne
+julia solverdummy-julia-parallel.jl M ../precice-config-parallel.xml SolverTwo
+```
+
+Example:
+```shell
+mpirun -n 4 python3 solverdummy-python-parallel.py ../precice-config-parallel.xml SolverOne MeshOne
+julia solverdummy-julia-parallel.jl 2 ../precice-config-parallel.xml SolverTwo
+```
+
+
 
 ## Remarks
 

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ julia solverdummy-julia-parallel.jl 2 ../precice-config-parallel.xml SolverTwo
 
 ## Setup 6: Julia and Python
 
-As with [Setup 5](#setup-5) you need to add `<master:sockets/>` to the `precice-config-parallel.xml` file in both participants.
+As with [Setup 5](#setup-5-julia-and-julia) you need to add `<master:sockets/>` to the `precice-config-parallel.xml` file in both participants.
 
 ```shell
 mpirun -n N python3 solverdummy-python-parallel.py ../precice-config-parallel.xml SolverOne MeshOne

--- a/README.md
+++ b/README.md
@@ -195,18 +195,18 @@ julia solverdummy-julia-parallel.jl 4 ../precice-config-parallel.xml SolverOne
 julia solverdummy-julia-parallel.jl 2 ../precice-config-parallel.xml SolverTwo
 ```
 
-## Setup 6: Julia and Python
+## Setup 6: Julia and C++
 
 As with [Setup 5](#setup-5-julia-and-julia) you need to add `<master:sockets/>` to the `precice-config-parallel.xml` file in both participants.
 
 ```shell
-mpirun -n N python3 solverdummy-python-parallel.py ../precice-config-parallel.xml SolverOne MeshOne
+mpirun -n N ./solverdummy-cpp-parallel ../precice-config-parallel.xml SolverOne MeshOne
 julia solverdummy-julia-parallel.jl M ../precice-config-parallel.xml SolverTwo
 ```
 
 Example:
 ```shell
-mpirun -n 4 python3 solverdummy-python-parallel.py ../precice-config-parallel.xml SolverOne MeshOne
+mpirun -n 4 ./solverdummy-cpp-parallel ../precice-config-parallel.xml SolverOne MeshOne
 julia solverdummy-julia-parallel.jl 2 ../precice-config-parallel.xml SolverTwo
 ```
 

--- a/julia/solverdummy-julia-parallel.jl
+++ b/julia/solverdummy-julia-parallel.jl
@@ -1,0 +1,99 @@
+using Distributed
+
+if size(ARGS, 1) < 3
+    println("ERROR: pass total processes number N, config path and solver name, 
+                example: julia solverdummy.jl 5 ./precice-config.xml SolverOne")
+    exit(1)
+end
+
+numberWorkers = parse(Int, ARGS[1]) - 1
+ConfigFileName = ARGS[2]
+SolverName = ARGS[3]
+
+# add --project flag if PreCICE is installed in a local Julia environment
+addprocs(numberWorkers; exeflags="--project")
+
+@everywhere begin
+
+using PreCICE
+
+commRank = myid() - 1
+commSize = nprocs()
+
+configFileName = $ConfigFileName
+solverName = $SolverName
+
+if solverName == "SolverOne"
+    meshName = "MeshOne"
+    dataWriteName = "dataOne"
+    dataReadName = "dataTwo"
+else
+    meshName = "MeshTwo"
+    dataReadName = "dataOne"
+    dataWriteName = "dataTwo"
+end
+
+println("""DUMMY ($commRank): Running solver dummy with preCICE config file "$configFileName", 
+            participant name "$solverName", and mesh name "$meshName" """)
+
+PreCICE.createSolverInterface(solverName, configFileName, commRank, commSize)
+
+meshID = PreCICE.getMeshID(meshName)
+dimensions = PreCICE.getDimensions()
+
+
+numberOfVertices = 3
+
+
+readDataID = PreCICE.getDataID(dataReadName, meshID)
+writeDataID = PreCICE.getDataID(dataWriteName, meshID)
+
+writeData = zeros(numberOfVertices, dimensions)
+
+vertices = Array{Float64,2}(undef, numberOfVertices, dimensions)
+
+for i = 1:numberOfVertices, j = 1:dimensions
+    vertices[i, j] = i
+end
+
+vertexIDs = PreCICE.setMeshVertices(meshID, vertices)
+
+let # setting local scope for dt outside of the while loop
+
+    dt = PreCICE.initialize()
+    readData = zeros(numberOfVertices, dimensions)
+
+    while PreCICE.isCouplingOngoing()
+
+        if PreCICE.isActionRequired(PreCICE.actionWriteIterationCheckpoint())
+            println("DUMMY ($commRank): Writing iteration checkpoint")
+            PreCICE.markActionFulfilled(PreCICE.actionWriteIterationCheckpoint())
+        end
+
+        if PreCICE.isReadDataAvailable()
+            readData = PreCICE.readBlockVectorData(readDataID, vertexIDs)
+        end
+
+        writeData = readData .+ 1.0
+
+        if PreCICE.isWriteDataRequired(dt)
+            PreCICE.writeBlockVectorData(writeDataID, vertexIDs, writeData)
+        end
+
+        dt = PreCICE.advance(dt)
+
+        if PreCICE.isActionRequired(PreCICE.actionReadIterationCheckpoint())
+            println("DUMMY ($commRank): Reading iteration checkpoint")
+            PreCICE.markActionFulfilled(PreCICE.actionReadIterationCheckpoint())
+        else
+            println("DUMMY ($commRank): Advancing in time")
+        end
+
+    end # while
+
+end # let scope
+
+PreCICE.finalize()
+println("DUMMY ($commRank): Closing Julia solver dummy...")
+
+end # begin


### PR DESCRIPTION
This PR adds parallel Julia solver dummies.

These dummies work with Julia's native parallelization, not with MPI. This is remarked in the Setup with other small changes to the precice-config that have to be made. 

Should the examples be at the end or in alphabetical order?