### PR TITLE
Remove mesh name from command line parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,66 +103,66 @@ Further information:
 ### Setup 1: C++ and C++
 
 ```
-mpirun -n N ./solverdummy-cpp-parallel ../precice-config-parallel.xml SolverOne MeshOne
-mpirun -n M ./solverdummy-cpp-parallel ../precice-config-parallel.xml SolverTwo MeshTwo
+mpirun -n N ./solverdummy-cpp-parallel ../precice-config-parallel.xml SolverOne
+mpirun -n M ./solverdummy-cpp-parallel ../precice-config-parallel.xml SolverTwo
 ```
 
 Example:
 ```
-mpirun -n 4 ./solverdummy-cpp-parallel ../precice-config-parallel.xml SolverOne MeshOne
-mpirun -n 2 ./solverdummy-cpp-parallel ../precice-config-parallel.xml SolverTwo MeshTwo
+mpirun -n 4 ./solverdummy-cpp-parallel ../precice-config-parallel.xml SolverOne
+mpirun -n 2 ./solverdummy-cpp-parallel ../precice-config-parallel.xml SolverTwo
 ```
 
 ### Setup 2: Python and Python
 
 ```
-mpirun -n N python3 solverdummy-python-parallel.py ../precice-config-parallel.xml SolverOne MeshOne
-mpirun -n M python3 solverdummy-python-parallel.py ../precice-config-parallel.xml SolverTwo MeshTwo
+mpirun -n N python3 solverdummy-python-parallel.py ../precice-config-parallel.xml SolverOne
+mpirun -n M python3 solverdummy-python-parallel.py ../precice-config-parallel.xml SolverTwo
 ```
 
 Example:
 ```
-mpirun -n 4 python3 solverdummy-python-parallel.py ../precice-config-parallel.xml SolverOne MeshOne
-mpirun -n 2 python3 solverdummy-python-parallel.py ../precice-config-parallel.xml SolverTwo MeshTwo
+mpirun -n 4 python3 solverdummy-python-parallel.py ../precice-config-parallel.xml SolverOne
+mpirun -n 2 python3 solverdummy-python-parallel.py ../precice-config-parallel.xml SolverTwo
 ```
 
 ### Setup 3: C++ and Python
 
 ```
-mpirun -n N ./solverdummy-cpp-parallel ../precice-config-parallel.xml SolverOne MeshOne
-mpirun -n M python3 solverdummy-python-parallel.py ../precice-config-parallel.xml SolverTwo MeshTwo
+mpirun -n N ./solverdummy-cpp-parallel ../precice-config-parallel.xml SolverOne
+mpirun -n M python3 solverdummy-python-parallel.py ../precice-config-parallel.xml SolverTwo
 ```
 
 Example:
 ```
-mpirun -n 4 ./solverdummy-cpp-parallel ../precice-config-parallel.xml SolverOne MeshOne
-mpirun -n 2 python3 solverdummy-python-parallel.py ../precice-config-parallel.xml SolverTwo MeshTwo
+mpirun -n 4 ./solverdummy-cpp-parallel ../precice-config-parallel.xml SolverOne
+mpirun -n 2 python3 solverdummy-python-parallel.py ../precice-config-parallel.xml SolverTwo
 ```
 
 ### Setup 4: Fortran and C++
 
 ```
-mpirun -n N ./solverdummy-cpp-parallel ../precice-config-parallel.xml SolverOne MeshOne
-mpirun -n M ./solverdummy-fortran-parallel ../precice-config-parallel.xml SolverTwo MeshTwo
+mpirun -n N ./solverdummy-cpp-parallel ../precice-config-parallel.xml SolverOne
+mpirun -n M ./solverdummy-fortran-parallel ../precice-config-parallel.xml SolverTwo
 ```
 
 Example:
 ```
-mpirun -n 4 ./solverdummy-cpp-parallel ../precice-config-parallel.xml SolverOne MeshOne
-mpirun -n 2 ./solverdummy-fortran-parallel ../precice-config-parallel.xml SolverTwo MeshTwo
+mpirun -n 4 ./solverdummy-cpp-parallel ../precice-config-parallel.xml SolverOne
+mpirun -n 2 ./solverdummy-fortran-parallel ../precice-config-parallel.xml SolverTwo
 ```
 
 ### Setup 4: C++ and C
 
 ```
-mpirun -n N ./solverdummy-cpp-parallel ../precice-config-parallel.xml SolverOne MeshOne
-mpirun -n N ./solverdummy-c-parallel ../precice-config-parallel.xml SolverOne MeshOne
+mpirun -n N ./solverdummy-cpp-parallel ../precice-config-parallel.xml SolverOne
+mpirun -n N ./solverdummy-c-parallel ../precice-config-parallel.xml SolverOne
 ```
 
 Example:
 ```
-mpirun -n 4 ./solverdummy-cpp-parallel ../precice-config-parallel.xml SolverOne MeshOne
-mpirun -n 2 ./solverdummy-c-parallel ../precice-config-parallel.xml  SolverTwo MeshTwo
+mpirun -n 4 ./solverdummy-cpp-parallel ../precice-config-parallel.xml SolverOne
+mpirun -n 2 ./solverdummy-c-parallel ../precice-config-parallel.xml  SolverTwo
 ```
 
 ### Setup 5: Julia and Julia
@@ -209,8 +209,6 @@ Example:
 mpirun -n 4 ./solverdummy-cpp-parallel ../precice-config-parallel.xml SolverOne MeshOne
 julia solverdummy-julia-parallel.jl 2 ../precice-config-parallel.xml SolverTwo
 ```
-
-
 
 ## Remarks
 

--- a/c/solverdummy-c-parallel.c
+++ b/c/solverdummy-c-parallel.c
@@ -18,7 +18,7 @@ int main(int argc, char **argv)
   int     numberOfVertices = 3;
   int     writeDataID      = -1;
   int     readDataID       = -1;
-
+  const char *meshName;
 
   MPI_Init( NULL, NULL );
 
@@ -39,8 +39,6 @@ int main(int argc, char **argv)
   const char *configFileName  = argv[1];
   const char *participantName = argv[2];
 
-  const char meshName[8] = (strcmp(participantName, "SolverOne") == 0) ? "MeshOne" : "MeshTwo";
-
   printf("DUMMY (%d): Running solver dummy with preCICE config file \"%s\", participant name \"%s\", and mesh name \"%s\".\n",
         commRank, configFileName, participantName, meshName);
 
@@ -54,10 +52,12 @@ int main(int argc, char **argv)
   if (strcmp(participantName, "SolverOne") == 0) {
     writeDataID = precicec_getDataID("dataOne", meshID);
     readDataID  = precicec_getDataID("dataTwo", meshID);
+    meshName = "MeshOne";
   }
   if (strcmp(participantName, "SolverTwo") == 0) {
     writeDataID = precicec_getDataID("dataTwo", meshID);
     readDataID  = precicec_getDataID("dataOne", meshID);
+    meshName = "MeshTwo";
   }
 
   dimensions = precicec_getDimensions();

--- a/c/solverdummy-c-parallel.c
+++ b/c/solverdummy-c-parallel.c
@@ -28,18 +28,18 @@ int main(int argc, char **argv)
   int commSize = -1;
   MPI_Comm_size(MPI_COMM_WORLD, &commSize);
 
-  if (argc != 4) {
+  if (argc != 3) {
     printf("Usage: ./solverdummy configFile solverName meshName\n\n");
     printf("Parameter description\n");
     printf("  configurationFile: Path and filename of preCICE configuration\n");
     printf("  solverName:        SolverDummy participant name in preCICE configuration\n");
-    printf("  meshName:          Mesh in preCICE configuration that carries read and write data\n");
     return 1;
   }
 
   const char *configFileName  = argv[1];
   const char *participantName = argv[2];
-  const char *meshName        = argv[3];
+
+  const char meshName[8] = (strcmp(participantName, "SolverOne") == 0) ? "MeshOne" : "MeshTwo";
 
   printf("DUMMY (%d): Running solver dummy with preCICE config file \"%s\", participant name \"%s\", and mesh name \"%s\".\n",
         commRank, configFileName, participantName, meshName);

--- a/c/solverdummy-c-parallel.c
+++ b/c/solverdummy-c-parallel.c
@@ -18,7 +18,7 @@ int main(int argc, char **argv)
   int     numberOfVertices = 3;
   int     writeDataID      = -1;
   int     readDataID       = -1;
-  const char *meshName;
+
 
   MPI_Init( NULL, NULL );
 
@@ -39,8 +39,11 @@ int main(int argc, char **argv)
   const char *configFileName  = argv[1];
   const char *participantName = argv[2];
 
-  printf("DUMMY (%d): Running solver dummy with preCICE config file \"%s\", participant name \"%s\", and mesh name \"%s\".\n",
-        commRank, configFileName, participantName, meshName);
+  const char *meshName = (strcmp(participantName, "SolverOne") == 0) ? "MeshOne" : "MeshTwo";
+
+  printf("DUMMY (%d): Running solver dummy with preCICE config file \"%s\" and participant name \"%s\".\n",
+        commRank, configFileName, participantName);
+
 
   const char *writeItCheckp = precicec_actionWriteIterationCheckpoint();
   const char *readItCheckp  = precicec_actionReadIterationCheckpoint();
@@ -52,12 +55,10 @@ int main(int argc, char **argv)
   if (strcmp(participantName, "SolverOne") == 0) {
     writeDataID = precicec_getDataID("dataOne", meshID);
     readDataID  = precicec_getDataID("dataTwo", meshID);
-    meshName = "MeshOne";
   }
   if (strcmp(participantName, "SolverTwo") == 0) {
     writeDataID = precicec_getDataID("dataTwo", meshID);
     readDataID  = precicec_getDataID("dataOne", meshID);
-    meshName = "MeshTwo";
   }
 
   dimensions = precicec_getDimensions();

--- a/cpp/solverdummy-cpp-parallel.cpp
+++ b/cpp/solverdummy-cpp-parallel.cpp
@@ -26,13 +26,12 @@ int main(int argc, char **argv)
 
   const std::string configFileName(argv[1]);
   const std::string solverName(argv[2]);
-
+  const std::string meshName = (solverName == "SolverOne") ? "MeshOne" : "MeshTwo";
 
   std::cout  << "DUMMY (" << commRank << "): Running solver dummy with preCICE config file \"" << configFileName << "\"and participant name.\"" << solverName << "\".\n";
 
   SolverInterface interface(solverName, configFileName, commRank, commSize);
 
-  std::string meshName;
   int         meshID     = interface.getMeshID(meshName);
   int         dimensions = interface.getDimensions();
   std::string dataWriteName;
@@ -42,12 +41,10 @@ int main(int argc, char **argv)
   if (solverName == "SolverOne") {
     dataWriteName = "dataOne";
     dataReadName  = "dataTwo";
-    meshName = "MeshOne";
   }
   if (solverName == "SolverTwo") {
     dataReadName  = "dataOne";
     dataWriteName = "dataTwo";
-    meshName = "MeshTwo";
   }
   const int readDataID  = interface.getDataID(dataReadName, meshID);
   const int writeDataID = interface.getDataID(dataWriteName, meshID);

--- a/cpp/solverdummy-cpp-parallel.cpp
+++ b/cpp/solverdummy-cpp-parallel.cpp
@@ -16,18 +16,17 @@ int main(int argc, char **argv)
   using namespace precice;
   using namespace precice::constants;
 
-  if (argc != 4) {
+  if (argc != 3) {
     std::cout << "Usage: ./solverdummy configFile solverName meshName\n\n";
     std::cout << "Parameter description\n";
     std::cout << "  configurationFile: Path and filename of preCICE configuration\n";
     std::cout << "  solverName:        SolverDummy participant name in preCICE configuration\n";
-    std::cout << "  meshName:          Mesh in preCICE configuration that carries read and write data\n";
     return 1;
   }
 
   const std::string configFileName(argv[1]);
   const std::string solverName(argv[2]);
-  const std::string meshName(argv[3]);
+  const std::string meshName = (solverName == "SolverOne") ? "MeshOne" : "MeshTwo";
 
   std::cout  << "DUMMY (" << commRank << "): Running solver dummy with preCICE config file \"" << configFileName << "\", participant name \"" << solverName << "\", and mesh name \"" << meshName << "\".\n";
 

--- a/cpp/solverdummy-cpp-parallel.cpp
+++ b/cpp/solverdummy-cpp-parallel.cpp
@@ -28,7 +28,7 @@ int main(int argc, char **argv)
   const std::string solverName(argv[2]);
 
 
-  std::cout  << "DUMMY (" << commRank << "): Running solver dummy with preCICE config file \"" << configFileName << "\", participant name \"" << solverName << "\", and mesh name \"" << meshName << "\".\n";
+  std::cout  << "DUMMY (" << commRank << "): Running solver dummy with preCICE config file \"" << configFileName << "\"and participant name.\"" << solverName << "\".\n";
 
   SolverInterface interface(solverName, configFileName, commRank, commSize);
 
@@ -42,12 +42,12 @@ int main(int argc, char **argv)
   if (solverName == "SolverOne") {
     dataWriteName = "dataOne";
     dataReadName  = "dataTwo";
-    meshName = "MeshOne"
+    meshName = "MeshOne";
   }
   if (solverName == "SolverTwo") {
     dataReadName  = "dataOne";
     dataWriteName = "dataTwo";
-    meshName = "MeshTwo"
+    meshName = "MeshTwo";
   }
   const int readDataID  = interface.getDataID(dataReadName, meshID);
   const int writeDataID = interface.getDataID(dataWriteName, meshID);

--- a/cpp/solverdummy-cpp-parallel.cpp
+++ b/cpp/solverdummy-cpp-parallel.cpp
@@ -26,12 +26,13 @@ int main(int argc, char **argv)
 
   const std::string configFileName(argv[1]);
   const std::string solverName(argv[2]);
-  const std::string meshName = (solverName == "SolverOne") ? "MeshOne" : "MeshTwo";
+
 
   std::cout  << "DUMMY (" << commRank << "): Running solver dummy with preCICE config file \"" << configFileName << "\", participant name \"" << solverName << "\", and mesh name \"" << meshName << "\".\n";
 
   SolverInterface interface(solverName, configFileName, commRank, commSize);
 
+  std::string meshName;
   int         meshID     = interface.getMeshID(meshName);
   int         dimensions = interface.getDimensions();
   std::string dataWriteName;
@@ -41,10 +42,12 @@ int main(int argc, char **argv)
   if (solverName == "SolverOne") {
     dataWriteName = "dataOne";
     dataReadName  = "dataTwo";
+    meshName = "MeshOne"
   }
   if (solverName == "SolverTwo") {
     dataReadName  = "dataOne";
     dataWriteName = "dataTwo";
+    meshName = "MeshTwo"
   }
   const int readDataID  = interface.getDataID(dataReadName, meshID);
   const int writeDataID = interface.getDataID(dataWriteName, meshID);

--- a/fortran/solverdummy-parallel-fortran.f90
+++ b/fortran/solverdummy-parallel-fortran.f90
@@ -31,15 +31,16 @@ PROGRAM main
   WRITE (*,FMT1) 'DUMMY(', rank, '): Starting Fortran solver dummy...'
   CALL getarg(1, config)
   CALL getarg(2, participantName)
-  CALL getarg(3, meshName)
 
   IF(participantName .eq. 'SolverOne') THEN
     writeDataName = 'dataOne'
     readDataName = 'dataTwo'
+    meshName = 'MeshOne'
   ENDIF
   IF(participantName .eq. 'SolverTwo') THEN
     writeDataName = 'dataTwo'
     readDataName = 'dataOne'
+    meshName = 'MeshTwo'
   ENDIF
 
   dt = 1

--- a/python/solverdummy-python-parallel.py
+++ b/python/solverdummy-python-parallel.py
@@ -12,7 +12,6 @@ parser = argparse.ArgumentParser()
 parser.add_argument("configurationFileName",
                     help="Name of the xml config file.", type=str)
 parser.add_argument("participantName", help="Name of the solver.", type=str)
-parser.add_argument("meshName", help="Name of the mesh.", type=str)
 
 try:
     args = parser.parse_args()
@@ -28,10 +27,12 @@ mesh_name = args.meshName
 if participant_name == 'SolverOne':
     write_data_name = 'dataOne'
     read_data_name = 'dataTwo'
+    mesh_name = 'MeshOne'
 
 if participant_name == 'SolverTwo':
     read_data_name = 'dataOne'
     write_data_name = 'dataTwo'
+    mesh_name = 'MeshTwo'
 
 num_vertices = 1  # Number of vertices
 

--- a/python/solverdummy-python-parallel.py
+++ b/python/solverdummy-python-parallel.py
@@ -22,7 +22,6 @@ except SystemExit:
 
 configuration_file_name = args.configurationFileName
 participant_name = args.participantName
-mesh_name = args.meshName
 
 if participant_name == 'SolverOne':
     write_data_name = 'dataOne'


### PR DESCRIPTION
This PR removes parameter from the command line that specifies the mesh. As the mesh name is solely dependent on the solver name, it is sufficient to set the mesh name based on the solver name.

Closes #6 