### PR TITLE
Add configuration for Julia solvers

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,32 +182,34 @@ Example:
 </participant>
 ```
 
+For convenience, the repository provides a `precice-config-parallel-julia.xml` configuration that can be used with the Julia solver dummy.
+
 Run the dummies with
 
 ```shell
-julia solverdummy-julia-parallel.jl N ../precice-config-parallel.xml SolverOne
-julia solverdummy-julia-parallel.jl M ../precice-config-parallel.xml SolverTwo
+julia solverdummy-julia-parallel.jl N ../precice-config-parallel-julia.xml SolverOne
+julia solverdummy-julia-parallel.jl M ../precice-config-parallel-julia.xml SolverTwo
 ```
 
 Example:
 ```shell
-julia solverdummy-julia-parallel.jl 4 ../precice-config-parallel.xml SolverOne
-julia solverdummy-julia-parallel.jl 2 ../precice-config-parallel.xml SolverTwo
+julia solverdummy-julia-parallel.jl 4 ../precice-config-parallel-julia.xml SolverOne
+julia solverdummy-julia-parallel.jl 2 ../precice-config-parallel-julia.xml SolverTwo
 ```
 
 ## Setup 6: Julia and C++
 
-As with [Setup 5](#setup-5-julia-and-julia) you need to add `<master:sockets/>` to the `precice-config-parallel.xml` file in both participants.
+As with [Setup 5](#setup-5-julia-and-julia) you need to add `<master:sockets/>` to the `precice-config-parallel.xml` file in both participants or you can used the provided `precice-config-parallel-julia.xml` configuration.
 
 ```shell
-mpirun -n N ./solverdummy-cpp-parallel ../precice-config-parallel.xml SolverOne MeshOne
-julia solverdummy-julia-parallel.jl M ../precice-config-parallel.xml SolverTwo
+mpirun -n N ./solverdummy-cpp-parallel ../precice-config-parallel-julia.xml SolverOne MeshOne
+julia solverdummy-julia-parallel.jl M ../precice-config-parallel-julia.xml SolverTwo
 ```
 
 Example:
 ```shell
-mpirun -n 4 ./solverdummy-cpp-parallel ../precice-config-parallel.xml SolverOne MeshOne
-julia solverdummy-julia-parallel.jl 2 ../precice-config-parallel.xml SolverTwo
+mpirun -n 4 ./solverdummy-cpp-parallel ../precice-config-parallel-julia.xml SolverOne MeshOne
+julia solverdummy-julia-parallel.jl 2 ../precice-config-parallel-julia.xml SolverTwo
 ```
 
 ## Remarks

--- a/precice-config-parallel-julia.xml
+++ b/precice-config-parallel-julia.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0"?>
+
+<precice-configuration>
+
+  <log>
+    <sink type="stream" output="stdout"  filter= "%Severity% > debug" format="preCICE:%ColorizedSeverity% %Message%" enabled="true" />
+  </log>
+
+  <solver-interface dimensions="3" >
+
+    <data:vector name="dataOne"  />
+    <data:vector name="dataTwo"  />
+
+    <mesh name="MeshOne">
+      <use-data name="dataOne" />
+      <use-data name="dataTwo" />
+    </mesh>
+
+    <mesh name="MeshTwo">
+      <use-data name="dataOne" />
+      <use-data name="dataTwo" />
+    </mesh>
+
+    <participant name="SolverOne">
+        <master:sockets/>
+        <use-mesh name="MeshOne" provide="yes"/>
+        <write-data name="dataOne" mesh="MeshOne" />
+        <read-data  name="dataTwo" mesh="MeshOne" />
+    </participant>
+
+    <participant name="SolverTwo">
+      <use-mesh name="MeshOne" from="SolverOne"/>
+      <use-mesh name="MeshTwo" provide="yes"/>
+      <mapping:nearest-neighbor   direction="write" from="MeshTwo" to="MeshOne" constraint="conservative"/>
+      <mapping:nearest-neighbor direction="read"  from="MeshOne" to="MeshTwo" constraint="consistent" />
+      <write-data name="dataTwo" mesh="MeshTwo" />
+      <read-data  name="dataOne" mesh="MeshTwo" />
+    </participant>
+
+    <m2n:sockets from="SolverOne" to="SolverTwo" exchange-directory=".."/>
+
+    <coupling-scheme:serial-implicit>
+      <participants first="SolverOne" second="SolverTwo" />
+      <max-time-windows value="2" />
+      <time-window-size value="1.0" />
+      <max-iterations value="2" />
+      <min-iteration-convergence-measure min-iterations="5" data="dataOne" mesh="MeshOne"/>
+      <exchange data="dataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+      <exchange data="dataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne"/>
+    </coupling-scheme:serial-implicit>
+  </solver-interface>
+
+</precice-configuration>


### PR DESCRIPTION
This adds a `precice-config-parallel-julia.xml` based on the instructions in the repository to couple the Julia dummies with each other or with other solvers.